### PR TITLE
Release for v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.9](https://github.com/orangekame3/stree/compare/v0.0.8...v0.0.9) - 2023-09-15
+- read profile region by @orangekame3 in https://github.com/orangekame3/stree/pull/12
+- add version file by @orangekame3 in https://github.com/orangekame3/stree/pull/14
+
 ## [v0.0.8](https://github.com/orangekame3/stree/compare/v0.0.7...v0.0.8) - 2023-09-13
 
 - skip adding node when empty path by @orangekame3 in <https://github.com/orangekame3/stree/pull/10>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## [v0.0.9](https://github.com/orangekame3/stree/compare/v0.0.8...v0.0.9) - 2023-09-15
-- read profile region by @orangekame3 in https://github.com/orangekame3/stree/pull/12
-- add version file by @orangekame3 in https://github.com/orangekame3/stree/pull/14
+
+- read profile region by @orangekame3 in <https://github.com/orangekame3/stree/pull/12>
+- add version file by @orangekame3 in <https://github.com/orangekame3/stree/pull/14>
 
 ## [v0.0.8](https://github.com/orangekame3/stree/compare/v0.0.7...v0.0.8) - 2023-09-13
 

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@ THE SOFTWARE.
 */
 package main
 
-const version = "0.0.8"
+const version = "0.0.9"


### PR DESCRIPTION
This pull request is for the next release as v0.0.9 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.9 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.8" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* read profile region by @orangekame3 in https://github.com/orangekame3/stree/pull/12
* add version file by @orangekame3 in https://github.com/orangekame3/stree/pull/14


**Full Changelog**: https://github.com/orangekame3/stree/compare/v0.0.8...v0.0.9