### PR TITLE
Release for v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
 ## [v0.0.11](https://github.com/orangekame3/stree/compare/v0.0.10...v0.0.11) - 2023-10-01
-- add CODEOWNERS by @orangekame3 in https://github.com/orangekame3/stree/pull/21
-- add credits by @orangekame3 in https://github.com/orangekame3/stree/pull/22
-- respect environment variables same as AWS CLI. by @fujiwara in https://github.com/orangekame3/stree/pull/19
-- gtree パッケージの更新 by @ddddddO in https://github.com/orangekame3/stree/pull/24
-- -level (-L) Option for Limit max depth by @mashiike in https://github.com/orangekame3/stree/pull/23
-- impl MFA by @ddddddO in https://github.com/orangekame3/stree/pull/25
-- update readme for release v0.0.11 by @orangekame3 in https://github.com/orangekame3/stree/pull/26
-- add article by @orangekame3 in https://github.com/orangekame3/stree/pull/27
+
+- add CODEOWNERS by @orangekame3 in <https://github.com/orangekame3/stree/pull/21>
+- add credits by @orangekame3 in <https://github.com/orangekame3/stree/pull/22>
+- respect environment variables same as AWS CLI. by @fujiwara in <https://github.com/orangekame3/stree/pull/19>
+- gtree パッケージの更新 by @ddddddO in <https://github.com/orangekame3/stree/pull/24>
+- -level (-L) Option for Limit max depth by @mashiike in <https://github.com/orangekame3/stree/pull/23>
+- impl MFA by @ddddddO in <https://github.com/orangekame3/stree/pull/25>
+- update readme for release v0.0.11 by @orangekame3 in <https://github.com/orangekame3/stree/pull/26>
+- add article by @orangekame3 in <https://github.com/orangekame3/stree/pull/27>
 
 ## [v0.0.10](https://github.com/orangekame3/stree/compare/v0.0.9...v0.0.10) - 2023-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v0.0.11](https://github.com/orangekame3/stree/compare/v0.0.10...v0.0.11) - 2023-10-01
+- add CODEOWNERS by @orangekame3 in https://github.com/orangekame3/stree/pull/21
+- add credits by @orangekame3 in https://github.com/orangekame3/stree/pull/22
+- respect environment variables same as AWS CLI. by @fujiwara in https://github.com/orangekame3/stree/pull/19
+- gtree パッケージの更新 by @ddddddO in https://github.com/orangekame3/stree/pull/24
+- -level (-L) Option for Limit max depth by @mashiike in https://github.com/orangekame3/stree/pull/23
+- impl MFA by @ddddddO in https://github.com/orangekame3/stree/pull/25
+- update readme for release v0.0.11 by @orangekame3 in https://github.com/orangekame3/stree/pull/26
+- add article by @orangekame3 in https://github.com/orangekame3/stree/pull/27
+
 ## [v0.0.10](https://github.com/orangekame3/stree/compare/v0.0.9...v0.0.10) - 2023-09-15
 
 ## [v0.0.9](https://github.com/orangekame3/stree/compare/v0.0.8...v0.0.9) - 2023-09-15

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@ THE SOFTWARE.
 */
 package main
 
-const version = "0.0.10"
+const version = "0.0.11"


### PR DESCRIPTION
This pull request is for the next release as v0.0.11 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.11 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.10" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* add CODEOWNERS by @orangekame3 in https://github.com/orangekame3/stree/pull/21
* add credits by @orangekame3 in https://github.com/orangekame3/stree/pull/22
* respect environment variables same as AWS CLI. by @fujiwara in https://github.com/orangekame3/stree/pull/19
* gtree パッケージの更新 by @ddddddO in https://github.com/orangekame3/stree/pull/24
* -level (-L) Option for Limit max depth by @mashiike in https://github.com/orangekame3/stree/pull/23
* impl MFA by @ddddddO in https://github.com/orangekame3/stree/pull/25
* update readme for release v0.0.11 by @orangekame3 in https://github.com/orangekame3/stree/pull/26
* add article by @orangekame3 in https://github.com/orangekame3/stree/pull/27

## New Contributors
* @fujiwara made their first contribution in https://github.com/orangekame3/stree/pull/19
* @ddddddO made their first contribution in https://github.com/orangekame3/stree/pull/24
* @mashiike made their first contribution in https://github.com/orangekame3/stree/pull/23

**Full Changelog**: https://github.com/orangekame3/stree/compare/v0.0.10...v0.0.11