### PR TITLE
Switch RoleしてS3にアクセスできるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Whether it's for verifying the file structure, sharing the structure with your t
 - **Colorized Output**: By default, `stree` provides a colorized tree structure, making it easy to differentiate between directories and files at a glance. This feature can be turned off with the `-n` or `--no-color` flag.
 - **LocalStack Support**: `stree` supports local testing with LocalStack, a fully functional local AWS cloud stack, thanks to the `--local` and `--endpoint-url` flags.
 - **Custom AWS Profile and Region**: Specify the AWS profile and region with the `--profile` and `--region` flags to override the default settings as needed.
-- **Switch Role Support**: Specify ARN of the role that can access the target S3 bucket with the `--swtch-role` flag.
+- **Switch Role Support**: Specify ARN of the role that can access the target S3 bucket with the `--switch-role` flag.
 - **Ease of Installation**: Install `stree` via Go, Homebrew, or by downloading the latest compiled binaries from the GitHub releases page.
 
 # Install

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Whether it's for verifying the file structure, sharing the structure with your t
 - **Colorized Output**: By default, `stree` provides a colorized tree structure, making it easy to differentiate between directories and files at a glance. This feature can be turned off with the `-n` or `--no-color` flag.
 - **LocalStack Support**: `stree` supports local testing with LocalStack, a fully functional local AWS cloud stack, thanks to the `--local` and `--endpoint-url` flags.
 - **Custom AWS Profile and Region**: Specify the AWS profile and region with the `--profile` and `--region` flags to override the default settings as needed.
+- **Switch Role Support**: Specify ARN of the role that can access the target S3 bucket with the `--swtch-role` flag.
 - **Ease of Installation**: Install `stree` via Go, Homebrew, or by downloading the latest compiled binaries from the GitHub releases page.
 
 # Install
@@ -197,6 +198,7 @@ Flags:
   -n, --no-color              Disable colorized output
   -p, --profile string        AWS profile to use (default "local")
   -r, --region string         AWS region to use (overrides the region specified in the profile)
+  -s, --switch-role string    Switch to ARN of the Role that can access the target S3 bucket
   -v, --version               version for stree
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ var (
 	endpointURL string
 	local       bool
 	noColor     bool
+	switchRole  string
 )
 
 var rootCmd = &cobra.Command{
@@ -57,6 +58,7 @@ var rootCmd = &cobra.Command{
 			AwsRegion:   awsRegion,
 			EndpointURL: endpointURL,
 			Local:       local,
+			SwitchRole:  switchRole,
 		}
 
 		s3Svc := pkg.InitializeAWSSession(s3Config)
@@ -103,6 +105,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&endpointURL, "endpoint-url", "e", "", "AWS endpoint URL to use (useful for local testing with LocalStack)")
 	rootCmd.Flags().BoolVarP(&local, "local", "l", false, "Use LocalStack configuration")
 	rootCmd.Flags().BoolVarP(&noColor, "no-color", "n", false, "Disable colorized output")
+	rootCmd.Flags().StringVarP(&switchRole, "switch-role", "s", "", "Role you want to switch to")
 }
 
 func extractBucketAndPrefix(input string) (string, string, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,7 +105,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&endpointURL, "endpoint-url", "e", "", "AWS endpoint URL to use (useful for local testing with LocalStack)")
 	rootCmd.Flags().BoolVarP(&local, "local", "l", false, "Use LocalStack configuration")
 	rootCmd.Flags().BoolVarP(&noColor, "no-color", "n", false, "Disable colorized output")
-	rootCmd.Flags().StringVarP(&switchRole, "switch-role", "s", "", "ARN of the role you want to switch to")
+	rootCmd.Flags().StringVarP(&switchRole, "switch-role", "s", "", "Switch to ARN of the Role that can access the target S3 bucket")
 }
 
 func extractBucketAndPrefix(input string) (string, string, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,7 +105,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&endpointURL, "endpoint-url", "e", "", "AWS endpoint URL to use (useful for local testing with LocalStack)")
 	rootCmd.Flags().BoolVarP(&local, "local", "l", false, "Use LocalStack configuration")
 	rootCmd.Flags().BoolVarP(&noColor, "no-color", "n", false, "Disable colorized output")
-	rootCmd.Flags().StringVarP(&switchRole, "switch-role", "s", "", "Role you want to switch to")
+	rootCmd.Flags().StringVarP(&switchRole, "switch-role", "s", "", "ARN of the role you want to switch to")
 }
 
 func extractBucketAndPrefix(input string) (string, string, error) {

--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -15,6 +16,7 @@ type S3Config struct {
 	AwsRegion   string
 	EndpointURL string
 	Local       bool
+	SwitchRole  string
 }
 
 // InitializeAWSSession returns an AWS session based on the provided configuration
@@ -49,6 +51,11 @@ func InitializeAWSSession(config S3Config) *s3.S3 {
 		sessOptions.Config.Region = aws.String(config.AwsRegion)
 	}
 	sess = session.Must(session.NewSessionWithOptions(sessOptions))
+
+	if config.SwitchRole != "" {
+		return s3.New(sess, &aws.Config{Credentials: stscreds.NewCredentials(sess, config.SwitchRole)})
+	}
+
 	return s3.New(sess)
 }
 


### PR DESCRIPTION
@orangekame3 

こちらのツールで、Switch RoleしてS3をツリー出力したいと思い、一つだけオプションを追加いたしました🙇

以下のドキュメントを参考に、AWS上でSwitchRoleできるように準備し、動作確認しました！
- [SwitchRoleのチュートリアル](https://docs.aws.amazon.com/ja_jp/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)
- [aws sdk doc](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/stscreds/)

確認が足りない等あれば、ご連絡お待ちしてます！

```console
~/github.com/ddddddO/stree
08:52:01 > go run *.go show-tree-bucket -p dev_david           # dev_david 自体には当該バケット(show-tree-bucket)を見る権限は無い
2023/09/23 08:52:27 failed to fetch S3 object keys: AccessDenied: Access Denied
        status code: 403, request id: T956TAXXXXXXXXXX, host id: kGxQ/04c9rlssucDV4o3s0C0dPSfefmTLHLFXSgIGGBUcdNLH4dVxogu5H5X0ERxxxxxxxxxxxxx
exit status 1
~/github.com/ddddddO/stree
08:52:26 > go run *.go show-tree-bucket -p dev_david -s arn:aws:iam::820544363308:role/S3ReadWriter_show-tree-bucket             # dev_david は、-s(--switch-role)で指定されたロールに切り替えられる設定がされており、このロールは当該バケット(show-tree-bucket)の読み書きが出来る権限が備わっている
show-tree-bucket
├── demo.gif
├── first
│   └── chil
│       └── chilchil
│           ├── verify.png
│           └── web_example.gif
└── second

4 directories, 3 files
~/github.com/ddddddO/stree
08:52:47 > go run *.go show-tree-bucket -p tester_jane           # tester_jane 自体に当該バケット(show-tree-bucket)を見る権限は無い
2023/09/23 08:52:59 failed to fetch S3 object keys: AccessDenied: Access Denied
        status code: 403, request id: G0GHETXXXXXXXXXX, host id: LwzAOleZlz8tvYQ9RyIlnRyRJ7qcXCLd8A0aLuaBNFTtVagRYQ2iFvwrHPD/wy/xxxxxxxxxxxxx
exit status 1
~/github.com/ddddddO/stree
08:52:59 > go run *.go show-tree-bucket -p tester_jane -s arn:aws:iam::820544363308:role/S3ReadWriter_show-tree-bucket             # tester_jane は、-s(--switch-role)で指定されたロールに切り替えられる設定をしていないため、Switch Roleができない
2023/09/23 08:53:15 failed to fetch S3 object keys: AccessDenied: User: arn:aws:iam::820544363308:user/Jane is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::820544363308:role/S3ReadWriter_show-tree-bucket
        status code: 403, request id: a995bd81-53f4-459c-8138-xxxxxxxxxxxx
exit status 1
~/github.com/ddddddO/stree
08:53:15 > go run *.go show-tree-bucket -p default           # default は、show-tree-bucket バケットの作成者. デグレチェックのため実行
show-tree-bucket
├── demo.gif
├── first
│   └── chil
│       └── chilchil
│           ├── verify.png
│           └── web_example.gif
└── second

4 directories, 3 files
~/github.com/ddddddO/stree
08:53:33 >
```

取り込んでいただけると幸いです🙇