### PR TITLE
respect environment variables same as AWS CLI.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,7 +129,7 @@ func defaultProfile() string {
 	if p, ok := os.LookupEnv("AWS_PROFILE"); ok {
 		return p
 	}
-	return "local"
+	return "default"
 }
 
 func defaultRegion() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,8 +98,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&awsProfile, "profile", "p", "local", "AWS profile to use")
-	rootCmd.Flags().StringVarP(&awsRegion, "region", "r", "", "AWS region to use (overrides the region specified in the profile)")
+	rootCmd.Flags().StringVarP(&awsProfile, "profile", "p", defaultProfile(), "AWS profile to use")
+	rootCmd.Flags().StringVarP(&awsRegion, "region", "r", defaultRegion(), "AWS region to use (overrides the region specified in the profile)")
 	rootCmd.Flags().StringVarP(&endpointURL, "endpoint-url", "e", "", "AWS endpoint URL to use (useful for local testing with LocalStack)")
 	rootCmd.Flags().BoolVarP(&local, "local", "l", false, "Use LocalStack configuration")
 	rootCmd.Flags().BoolVarP(&noColor, "no-color", "n", false, "Disable colorized output")
@@ -123,4 +123,20 @@ func extractBucketAndPrefix(input string) (string, string, error) {
 // SetVersionInfo sets version and date to rootCmd
 func SetVersionInfo(version, date string) {
 	rootCmd.Version = fmt.Sprintf("%s (Built on %s)", version, date)
+}
+
+func defaultProfile() string {
+	if p, ok := os.LookupEnv("AWS_PROFILE"); ok {
+		return p
+	}
+	return "local"
+}
+
+func defaultRegion() string {
+	for _, e := range []string{"AWS_REGION", "AWS_DEFAULT_REGION"} {
+		if r, ok := os.LookupEnv(e); ok {
+			return r
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Hi. Thank you for the great tool!

stree seems does not look AWS_REGON, AWS_DEFAULT_REGION, and AWS_PROFILE environment variables. 
I use these variables normally when using CLI tools for AWS.

So I wrote a patch to set these variables as the default value of CLI parameters.

See also https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list