### PR TITLE
-level (-L) Option for Limit max depth

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ var (
 	endpointURL string
 	local       bool
 	noColor     bool
+	level       int
 )
 
 var rootCmd = &cobra.Command{
@@ -65,8 +66,11 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("failed to extract bucket and prefix: %v", err)
 		}
-
-		keys, err := pkg.FetchS3ObjectKeys(s3Svc, bucket, prefix)
+		var maxDepth *int
+		if level > 0 {
+			maxDepth = &level
+		}
+		keys, err := pkg.FetchS3ObjectKeys(s3Svc, bucket, prefix, maxDepth)
 		if err != nil {
 			log.Fatalf("failed to fetch S3 object keys: %v", err)
 			return
@@ -103,6 +107,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&endpointURL, "endpoint-url", "e", "", "AWS endpoint URL to use (useful for local testing with LocalStack)")
 	rootCmd.Flags().BoolVarP(&local, "local", "l", false, "Use LocalStack configuration")
 	rootCmd.Flags().BoolVarP(&noColor, "no-color", "n", false, "Disable colorized output")
+	rootCmd.Flags().IntVarP(&level, "level", "L", 0, "Descend only level directories")
 }
 
 func extractBucketAndPrefix(input string) (string, string, error) {


### PR DESCRIPTION
Hi. Thank you for the usefull tool.

The `tree` command has a --level (-L) option that specifies a depth limit.
This option is currently not implemented for `stree`.
When using `stree` with a large number of deeply nested S3 buckets, it takes a long time to draw, so I implemented the -L option and looked at it.

