### PR TITLE
Release for v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.13](https://github.com/orangekame3/stree/compare/v0.0.12...v0.0.13) - 2024-07-07
+- [feat]:  add `-f` option for print full path by @orangekame3 in https://github.com/orangekame3/stree/pull/34
+
 ## [v0.0.12](https://github.com/orangekame3/stree/compare/v0.0.11...v0.0.12) - 2023-11-18
 - Update README.md by @orangekame3 in https://github.com/orangekame3/stree/pull/28
 - Modify warning by @ddddddO in https://github.com/orangekame3/stree/pull/31

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@ THE SOFTWARE.
 */
 package main
 
-const version = "0.0.12"
+const version = "0.0.13"


### PR DESCRIPTION
This pull request is for the next release as v0.0.13 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.13 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.12" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [feat]:  add `-f` option for print full path by @orangekame3 in https://github.com/orangekame3/stree/pull/34


**Full Changelog**: https://github.com/orangekame3/stree/compare/v0.0.12...v0.0.13