### PR TITLE
Release for v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [v0.0.15](https://github.com/orangekame3/stree/compare/v0.0.14...v0.0.15) - 2024-07-08
-- [bug]: Fix `-f` option by @orangekame3 in https://github.com/orangekame3/stree/pull/37
+
+- [bug]: Fix `-f` option by @orangekame3 in <https://github.com/orangekame3/stree/pull/37>
 
 ## [v0.0.14](https://github.com/orangekame3/stree/compare/v0.0.13...v0.0.14) - 2024-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.15](https://github.com/orangekame3/stree/compare/v0.0.14...v0.0.15) - 2024-07-08
+- [bug]: Fix `-f` option by @orangekame3 in https://github.com/orangekame3/stree/pull/37
+
 ## [v0.0.14](https://github.com/orangekame3/stree/compare/v0.0.13...v0.0.14) - 2024-07-07
 
 - [chore]: Fix version by @orangekame3 in <https://github.com/orangekame3/stree/pull/35>

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ package cmd
 import "fmt"
 
 // Version is a version of this application.
-const Version = "0.0.14"
+const Version = "0.0.15"
 
 // SetVersionInfo sets version and date to rootCmd
 func SetVersionInfo(version, date string) {


### PR DESCRIPTION
This pull request is for the next release as v0.0.15 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.15 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.14" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [bug]: Fix `-f` option by @orangekame3 in https://github.com/orangekame3/stree/pull/37


**Full Changelog**: https://github.com/orangekame3/stree/compare/v0.0.14...v0.0.15